### PR TITLE
Add task to enable disable explicity log rotation using container linux's logrotate daemon

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ docker_gc_img: "spotify/docker-gc"
 install_rkt_gc: True
 docker_gc_frequency: "daily"
 docker_gc_grace_period_seconds: "3600"
+logrotate: False
 rkt_gc_frequency: "daily"
 rkt_gc_grace_period: "24h"
 ntp_servers: []

--- a/files/docker-container-logrotate
+++ b/files/docker-container-logrotate
@@ -1,0 +1,9 @@
+/var/lib/docker/containers/*/*.log {
+  rotate 0
+  daily
+  notifempty
+  nocompress
+  size 20k
+  missingok
+  copytruncate
+}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,3 +11,7 @@
   sudo: yes
   command: timedatectl set-ntp true
   notify: Reload systemd-timesyncd
+
+- name: Run logrotate
+  become: yes
+  command: /usr/sbin/logrotate -fv /etc/logrotate.d/docker-container-logrotate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,18 @@
   sudo: yes
   when: docker_gc_timer.changed
 
+- name: Enable logrotate for docker containers
+  become: yes
+  copy: src=docker-container-logrotate dest=/etc/logrotate.d/docker-container-logrotate
+  notify:
+     - Run logrotate
+  when: logrotate
+
+- name: Disable logrotate for docker containers
+  become: yes
+  file: path=/etc/logrotate.d/docker-container-logrotate state=absent
+  when: not logrotate
+
 - name: Create env.d dir
   sudo: yes
   file: path=/etc/env.d state=directory mode=0755


### PR DESCRIPTION
Tests: log snippets only

VAR logrotate=False
----------------------
```
$ ansible-playbook -vv -i inventory/log2 cluster.yml --tags=setup
...
TASK [vmware.coreos-setup : Enable logrotate for docker containers] ************
task path: /dbc/sc-dbc1214/vmohite/decc/log2/coreos-ansible/roles/vmware.coreos-setup/tasks/main.yml:66
changed: [coreos-cluster-2] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
changed: [coreos-cluster-1] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
changed: [coreos-cluster-3] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
changed: [coreos-cluster-4] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
changed: [coreos-cluster-6] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
changed: [coreos-cluster-5] => {"changed": true, "path": "/etc/logrotate.d/docker-container-logrotate", "state": "absent"}
```

VAR logrotate=False
----------------------
```
$ ansible-playbook -vv -i inventory/log2 cluster.yml --tags=setup
...
TASK [vmware.coreos-setup : Enable logrotate for docker containers] ************
task path: /dbc/sc-dbc1214/vmohite/decc/log2/coreos-ansible/roles/vmware.coreos-setup/tasks/main.yml:59
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-3] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.72-5942950794737/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-1] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.72-44412235421539/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-5] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.75-242115826292484/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-2] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.72-197697373185991/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-6] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.77-141612961459501/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-4] => {"changed": true, "checksum": "92cd3122756a956e8b4220cfd9e102cbf186e3a0", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "69de3c3597748285c4af61f43fdc39cf", "mode": "0644", "owner": "root", "size": 123, "src": "/home/core/.ansible/tmp/ansible-tmp-1499908553.74-149750084772239/source", "state": "file", "uid": 0}

...

RUNNING HANDLER [vmware.coreos-setup : Run logrotate] **************************
changed: [coreos-cluster-3] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.008982", "end": "2017-07-13 01:16:07.748322", "rc": 0, "start": "2017-07-13 01:16:07.739340", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/181b5a30b7335b6c0a8ab7d3c75973599c5e4d904eaa37701bc03f10f6b174b6/181b5a30b7335b6c0a8ab7d3c75973599c5e4d904eaa37701bc03f10f6b174b6-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/19499622a0f58e7f353e5fcb823a11362b9531ff48658f108ff1f02266024478/19499622a0f58e7f353e5fcb823a11362b9531ff48658f108ff1f02266024478-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/1ad6847f843b2f061747f71aafd736441fb896c13c14e534ce009c988c297968/1ad6847f843b2f061747f71aafd736441fb896c13c14e534ce009c988c297968-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/2cab4c4d23a11c46dfaee4c67719e53adb61e41edc38120607f4c83b1cdfe315/2cab4c4d23a11c46dfaee4c67719e53adb61e41edc38120607f4c83b1cdfe315-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/54f4c297969e72153a1498e0414c6872ae8c968a0432536e64b4080b3e6b2871/54f4c297969e72153a1498e0414c6872ae8c968a0432536e64b4080b3e6b2871-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/59e282c3074b26014df00dd8840640182a44ba7f58c226246b514189ad82a56d/59e282c3074b26014df00dd8840640182a44ba7f58c226246b514189ad82a56d-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/87603063416c78558283c0914425d22d0ca62cfd6edd2e741de2cc346b7bed05/87603063416c78558283c0914425d22d0ca62cfd6edd2e741de2cc346b7bed05-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/9cd3ad3e5dbd56757a14d65589afaa38566204aa5883c3777acb9999b2837b55/9cd3ad3e5dbd56757a14d65589afaa38566204aa5883c3777acb9999b2837b55-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a2053cc4b8ee474f6f98be96a74e2a705ef07d98d0d46a76b5fa1fdade5a6913/a2053cc4b8ee474f6f98be96a74e2a705ef07d98d0d46a76b5fa1fdade5a6913-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c3b16a0d68d1c05fd14dbfc51ab80c0350e7fac436bb6a0cae24df69fcab821f/c3b16a0d68d1c05fd14dbfc51ab80c0350e7fac436bb6a0cae24df69fcab821f-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c5a6041d1b279455aa99201211f1ef3340c01ae3caec6b7baf3a98236f725670/c5a6041d1b279455aa99201211f1ef3340c01ae3caec6b7baf3a98236f725670-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-1] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.007544", "end": "2017-07-13 01:16:07.761675", "rc": 0, "start": "2017-07-13 01:16:07.754131", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/*/*.log", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-2] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.012128", "end": "2017-07-13 01:16:07.783819", "rc": 0, "start": "2017-07-13 01:16:07.771691", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/469bdc33d1bd2c742e8542d3236d705f2243f90c203abb0c47a3cb763a27fa40/469bdc33d1bd2c742e8542d3236d705f2243f90c203abb0c47a3cb763a27fa40-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/4e0a7ba4cc182c612ad5cd8ca03b6135bc53bdc38baa70775cdc510472149e33/4e0a7ba4cc182c612ad5cd8ca03b6135bc53bdc38baa70775cdc510472149e33-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/82d82120ee2bc063e0ec20246311655447d15650b6b87c45424235e11311fc23/82d82120ee2bc063e0ec20246311655447d15650b6b87c45424235e11311fc23-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/84050a265058166b4ff571e7ec6c4e0e5c261433984c6259feeca6bd76dcdd2a/84050a265058166b4ff571e7ec6c4e0e5c261433984c6259feeca6bd76dcdd2a-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/853de0de60e8fc5989a8a484100490485a93bf71b1f02e4bc6789463a0840f37/853de0de60e8fc5989a8a484100490485a93bf71b1f02e4bc6789463a0840f37-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/ac95441949ca063acb0923d6637066563be687ad4b5af97339f069688589075f/ac95441949ca063acb0923d6637066563be687ad4b5af97339f069688589075f-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c1c2dadd7eb9b5206cb20ac245c65b08892a4fc42b90491c7080d940ceec932b/c1c2dadd7eb9b5206cb20ac245c65b08892a4fc42b90491c7080d940ceec932b-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c391c7d625f744115d1ce91c5127b96b928dc1d4b04d5969d241dcefd3cff539/c391c7d625f744115d1ce91c5127b96b928dc1d4b04d5969d241dcefd3cff539-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/cff14bf1da8e4b718c7d99c583e91f65e0da09e3bb0f2f7e7b21e4ba90533220/cff14bf1da8e4b718c7d99c583e91f65e0da09e3bb0f2f7e7b21e4ba90533220-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/e730565e080e013d4d3cde93b0ada610180001cf080c92154266a2ad9a9ace05/e730565e080e013d4d3cde93b0ada610180001cf080c92154266a2ad9a9ace05-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/fe1e3adb4bb8c14a5023c6587634bb317ac4f10f196a6a24731c90ac8f737e34/fe1e3adb4bb8c14a5023c6587634bb317ac4f10f196a6a24731c90ac8f737e34-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-5] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.033225", "end": "2017-07-13 01:16:07.806019", "rc": 0, "start": "2017-07-13 01:16:07.772794", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/0b691d4cdbf7f913739a58f9df5cbe438ada72bfc774295f61d4439494e41512/0b691d4cdbf7f913739a58f9df5cbe438ada72bfc774295f61d4439494e41512-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log\n  log needs rotating\nconsidering log /var/lib/docker/containers/304e9b2003085007c27ca10c03e3c96187a09f428d1d5541c87fba616b03222c/304e9b2003085007c27ca10c03e3c96187a09f428d1d5541c87fba616b03222c-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/6655132ee0edd530e2c79c165763261e0fba76bf6daaf106593ebe8542dd0224/6655132ee0edd530e2c79c165763261e0fba76bf6daaf106593ebe8542dd0224-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/d11f4b74ada656363582ec32d2b818493ebca803a2ebad44730f69eebe68bd63/d11f4b74ada656363582ec32d2b818493ebca803a2ebad44730f69eebe68bd63-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/dd51a27938ea36615e2f183f91ae36081d8e2e8a8c17045f8350e86e4d9edd7c/dd51a27938ea36615e2f183f91ae36081d8e2e8a8c17045f8350e86e4d9edd7c-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/df5128971f0ac81b362715a3d7827758d410343be2dd2f7cba4c1ae64607f03f/df5128971f0ac81b362715a3d7827758d410343be2dd2f7cba4c1ae64607f03f-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/fe920bc6e3ba6c52578537fc5b43ab14fd261da68f00b23a878aa526aaa05760/fe920bc6e3ba6c52578537fc5b43ab14fd261da68f00b23a878aa526aaa05760-json.log\n  log does not need rotating (log is empty)rotating log /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log, log->rotateCount is 0\ndateext suffix '-20170713'\nglob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'\nrenaming /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.1 to /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.2 (rotatecount 1, logstart 1, i 1), \nrenaming /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.0 to /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.1 (rotatecount 1, logstart 1, i 0), \nold log /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.0 does not exist\ncopying /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log to /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.1\ntruncating /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log\nremoving old log /var/lib/docker/containers/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071/1e51448c08381e04f642abe9c7cd8a43648692c764854f7fae55da18d997a071-json.log.2", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-4] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.010227", "end": "2017-07-13 01:16:07.798751", "rc": 0, "start": "2017-07-13 01:16:07.788524", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/25db5c7f46d47c66886e931d3be14f2a12efec12a71e111cfa57c5071850ff70/25db5c7f46d47c66886e931d3be14f2a12efec12a71e111cfa57c5071850ff70-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/377eb80d31c566427170e04d8248ac5898954cc14971a13ffb90be60ca1abd1e/377eb80d31c566427170e04d8248ac5898954cc14971a13ffb90be60ca1abd1e-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/45a3fd88ac55c11af3e9356fb077c1352dbb67c6a299021419036ed089af2e21/45a3fd88ac55c11af3e9356fb077c1352dbb67c6a299021419036ed089af2e21-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a5cda654c570b924455e5ed882e888503d3906a8da3b693e36743ac8e376560b/a5cda654c570b924455e5ed882e888503d3906a8da3b693e36743ac8e376560b-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-6] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.024666", "end": "2017-07-13 01:16:07.848260", "rc": 0, "start": "2017-07-13 01:16:07.823594", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/095ea87af3ab5718912c40952fbf324687728115cf4fec68b108cbc6a0cf1153/095ea87af3ab5718912c40952fbf324687728115cf4fec68b108cbc6a0cf1153-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/2ca44c6f2c21dd51d6da91bc97ae7b0f2a72b78a0a99ab588d50f9f0fffd8c6e/2ca44c6f2c21dd51d6da91bc97ae7b0f2a72b78a0a99ab588d50f9f0fffd8c6e-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/5fea68ec0b476a2d1b9940b66c18434ebb8fb819fbcc515cf45892cb31297a6d/5fea68ec0b476a2d1b9940b66c18434ebb8fb819fbcc515cf45892cb31297a6d-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log\n  log needs rotating\nconsidering log /var/lib/docker/containers/71b1857e769d0042ef8cc84dbbfa3b18a57828d09cb78106e6f5abff923e6d7c/71b1857e769d0042ef8cc84dbbfa3b18a57828d09cb78106e6f5abff923e6d7c-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/72cf12867465385c51fd6f925dd0c84bdc98b06eacf4cf5813327bea7cebb228/72cf12867465385c51fd6f925dd0c84bdc98b06eacf4cf5813327bea7cebb228-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/741ca934663fe90ce2b3288af7bfb30e5bb1f6ba0b9750554475a78755fb0638/741ca934663fe90ce2b3288af7bfb30e5bb1f6ba0b9750554475a78755fb0638-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a9f160613f79b42b77861ec32e581e640eedc38a1c3362184b7e82af79119251/a9f160613f79b42b77861ec32e581e640eedc38a1c3362184b7e82af79119251-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/b974c45737a9e624294325ca71077a1cb95e3cfea7b011623caf0abd35958831/b974c45737a9e624294325ca71077a1cb95e3cfea7b011623caf0abd35958831-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/dcc483ead3a6882b29c3dcf4d05ecc604179e50434236331b94034e5bd43a068/dcc483ead3a6882b29c3dcf4d05ecc604179e50434236331b94034e5bd43a068-json.log\n  log does not need rotating (log is empty)rotating log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log, log->rotateCount is 0\ndateext suffix '-20170713'\nglob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'\nrenaming /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1 to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.2 (rotatecount 1, logstart 1, i 1), \nrenaming /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.0 to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1 (rotatecount 1, logstart 1, i 0), \nold log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.0 does not exist\ncopying /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1\ntruncating /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log\nremoving old log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.2", "stdout": "", "stdout_lines": [], "warnings": []}
```

------------

Please note, CoreOS' logrotate service runs daily, so I am looking into if we can change that frequency.
Also, if new pod is created with new log file, that gets rotated by the `logrotate` daemon.  Seems there were some issues few years ago, but not anymore.
I should also mention that to solve the issue of docker not logging to a rotated log file, we have to use the `copytruncate` option. Which means the logs are copied over to another file before being truncated in place. The log file remains open for the docker to continue to write to it. This means, even though we have set `rotate 0` option, we will still have one copy of old log available on the node. Note that there is a very small time slice between copying the file and truncating it, so  some  logging  data  might be lost. Given our size of logs, copying should not take much time, loss should be minimum.