### PR TITLE
Update logrotate to run hourly instead of daiily. Also updated a few log configs.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ install_rkt_gc: True
 docker_gc_frequency: "daily"
 docker_gc_grace_period_seconds: "3600"
 logrotate: False
+logrotation_timer_frequency: "*:0/15"
 rkt_gc_frequency: "daily"
 rkt_gc_grace_period: "24h"
 ntp_servers: []

--- a/files/docker-container-logrotate
+++ b/files/docker-container-logrotate
@@ -1,9 +1,11 @@
 /var/lib/docker/containers/*/*.log {
   rotate 0
-  daily
+  hourly
   notifempty
   nocompress
-  size 20k
+  size 10M
   missingok
   copytruncate
+  nodateext
+  maxage 1
 }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,10 @@
   command: timedatectl set-ntp true
   notify: Reload systemd-timesyncd
 
+- name: Reload logrotate.timer
+  become: yes
+  command: systemctl restart logrotate.timer
+
 - name: Run logrotate
   become: yes
   command: /usr/sbin/logrotate -fv /etc/logrotate.d/docker-container-logrotate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,13 @@
   sudo: yes
   when: docker_gc_timer.changed
 
+- name: Update logrotate timer to run every hour
+  become: yes
+  template: src=logrotate.timer dest=/etc/systemd/system/logrotate.timer
+  notify:
+     - Reload logrotate.timer
+  when: logrotate
+
 - name: Enable logrotate for docker containers
   become: yes
   copy: src=docker-container-logrotate dest=/etc/logrotate.d/docker-container-logrotate

--- a/templates/logrotate.timer
+++ b/templates/logrotate.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Log Rotation on '{{logrotation_timer_frequency}}' cadence
+
+[Timer]
+OnCalendar={{logrotation_timer_frequency}}
+AccuracySec=1h
+Persistent=true


### PR DESCRIPTION
### Description:
DNS logs are growing at a faster rate and `daily` log rotation doesn't seem enough. This change fixes that issue by rotating the logs every hour.
Also updated a few log rotation configs:
- Updated log size to a more realistic limit
- `dateext` (default in coreos config) is an extention designed for daily logs. Removing it.
- `maxage` will ensure the old logs older than 1 day gets deleted.

### Test snippets

```bash
$ ansible-playbook -vv -i inventory/log2 cluster.yml --tags=setup

...

TASK [vmware.coreos-setup : Update logrotate timer to run every hour] **********
task path: /dbc/sc-dbc1214/vmohite/decc/log2/coreos-ansible/roles/vmware.coreos-setup/tasks/main.yml:59
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-1] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.15-18514636007724/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-4] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.19-34533296877163/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-3] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.17-107423392137990/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-2] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.17-61800654279382/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-6] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.22-164987076902493/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Reload systemd
changed: [coreos-cluster-5] => {"changed": true, "checksum": "7a0d29e2e82c6b673c0338dfcc48917c651c3cc4", "dest": "/etc/systemd/system/logrotate.timer", "gid": 0, "group": "root", "md5sum": "f629a519790fe94e828b7c8dcda1398a", "mode": "0644", "owner": "root", "size": 97, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331278.21-46354540036726/source", "state": "file", "uid": 0}

TASK [vmware.coreos-setup : Enable logrotate for docker containers] ************
task path: /dbc/sc-dbc1214/vmohite/decc/log2/coreos-ansible/roles/vmware.coreos-setup/tasks/main.yml:65
ok: [coreos-cluster-5] => {"changed": false, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/logrotate.d/docker-container-logrotate", "size": 145, "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-1] => {"changed": true, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "f2cf5354d5cee0850e596d6862fa386c", "mode": "0644", "owner": "root", "size": 145, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331279.16-250066285232190/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-3] => {"changed": true, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "f2cf5354d5cee0850e596d6862fa386c", "mode": "0644", "owner": "root", "size": 145, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331279.17-128052435758073/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-2] => {"changed": true, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "f2cf5354d5cee0850e596d6862fa386c", "mode": "0644", "owner": "root", "size": 145, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331279.17-131829553906247/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-4] => {"changed": true, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "f2cf5354d5cee0850e596d6862fa386c", "mode": "0644", "owner": "root", "size": 145, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331279.18-23863334772693/source", "state": "file", "uid": 0}
NOTIFIED HANDLER Run logrotate
changed: [coreos-cluster-6] => {"changed": true, "checksum": "5f635ff46535ff3efbc3edddca8450005220f99b", "dest": "/etc/logrotate.d/docker-container-logrotate", "gid": 0, "group": "root", "md5sum": "f2cf5354d5cee0850e596d6862fa386c", "mode": "0644", "owner": "root", "size": 145, "src": "/home/core/.ansible/tmp/ansible-tmp-1500331279.21-242351585048296/source", "state": "file", "uid": 0}

...

RUNNING HANDLER [vmware.coreos-setup : Reload systemd] *************************
changed: [coreos-cluster-1] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.059724", "end": "2017-07-17 22:41:33.079114", "rc": 0, "start": "2017-07-17 22:41:33.019390", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-3] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.084956", "end": "2017-07-17 22:41:33.135005", "rc": 0, "start": "2017-07-17 22:41:33.050049", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-4] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.093708", "end": "2017-07-17 22:41:33.138152", "rc": 0, "start": "2017-07-17 22:41:33.044444", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-2] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.084197", "end": "2017-07-17 22:41:33.158144", "rc": 0, "start": "2017-07-17 22:41:33.073947", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-5] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.100024", "end": "2017-07-17 22:41:33.168447", "rc": 0, "start": "2017-07-17 22:41:33.068423", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-6] => {"changed": true, "cmd": ["systemctl", "--system", "daemon-reload"], "delta": "0:00:00.103451", "end": "2017-07-17 22:41:33.206190", "rc": 0, "start": "2017-07-17 22:41:33.102739", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

RUNNING HANDLER [vmware.coreos-setup : Run logrotate] **************************
changed: [coreos-cluster-1] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.008848", "end": "2017-07-17 22:41:33.583082", "rc": 0, "start": "2017-07-17 22:41:33.574234", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/*/*.log", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-3] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.010303", "end": "2017-07-17 22:41:33.604051", "rc": 0, "start": "2017-07-17 22:41:33.593748", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/181b5a30b7335b6c0a8ab7d3c75973599c5e4d904eaa37701bc03f10f6b174b6/181b5a30b7335b6c0a8ab7d3c75973599c5e4d904eaa37701bc03f10f6b174b6-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/19499622a0f58e7f353e5fcb823a11362b9531ff48658f108ff1f02266024478/19499622a0f58e7f353e5fcb823a11362b9531ff48658f108ff1f02266024478-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/1ad6847f843b2f061747f71aafd736441fb896c13c14e534ce009c988c297968/1ad6847f843b2f061747f71aafd736441fb896c13c14e534ce009c988c297968-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/2cab4c4d23a11c46dfaee4c67719e53adb61e41edc38120607f4c83b1cdfe315/2cab4c4d23a11c46dfaee4c67719e53adb61e41edc38120607f4c83b1cdfe315-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/54f4c297969e72153a1498e0414c6872ae8c968a0432536e64b4080b3e6b2871/54f4c297969e72153a1498e0414c6872ae8c968a0432536e64b4080b3e6b2871-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/59e282c3074b26014df00dd8840640182a44ba7f58c226246b514189ad82a56d/59e282c3074b26014df00dd8840640182a44ba7f58c226246b514189ad82a56d-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/87603063416c78558283c0914425d22d0ca62cfd6edd2e741de2cc346b7bed05/87603063416c78558283c0914425d22d0ca62cfd6edd2e741de2cc346b7bed05-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/9cd3ad3e5dbd56757a14d65589afaa38566204aa5883c3777acb9999b2837b55/9cd3ad3e5dbd56757a14d65589afaa38566204aa5883c3777acb9999b2837b55-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a2053cc4b8ee474f6f98be96a74e2a705ef07d98d0d46a76b5fa1fdade5a6913/a2053cc4b8ee474f6f98be96a74e2a705ef07d98d0d46a76b5fa1fdade5a6913-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c3b16a0d68d1c05fd14dbfc51ab80c0350e7fac436bb6a0cae24df69fcab821f/c3b16a0d68d1c05fd14dbfc51ab80c0350e7fac436bb6a0cae24df69fcab821f-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c5a6041d1b279455aa99201211f1ef3340c01ae3caec6b7baf3a98236f725670/c5a6041d1b279455aa99201211f1ef3340c01ae3caec6b7baf3a98236f725670-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-4] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.010955", "end": "2017-07-17 22:41:33.612055", "rc": 0, "start": "2017-07-17 22:41:33.601100", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/25db5c7f46d47c66886e931d3be14f2a12efec12a71e111cfa57c5071850ff70/25db5c7f46d47c66886e931d3be14f2a12efec12a71e111cfa57c5071850ff70-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/377eb80d31c566427170e04d8248ac5898954cc14971a13ffb90be60ca1abd1e/377eb80d31c566427170e04d8248ac5898954cc14971a13ffb90be60ca1abd1e-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/45a3fd88ac55c11af3e9356fb077c1352dbb67c6a299021419036ed089af2e21/45a3fd88ac55c11af3e9356fb077c1352dbb67c6a299021419036ed089af2e21-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a5cda654c570b924455e5ed882e888503d3906a8da3b693e36743ac8e376560b/a5cda654c570b924455e5ed882e888503d3906a8da3b693e36743ac8e376560b-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-2] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.009294", "end": "2017-07-17 22:41:33.621114", "rc": 0, "start": "2017-07-17 22:41:33.611820", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/469bdc33d1bd2c742e8542d3236d705f2243f90c203abb0c47a3cb763a27fa40/469bdc33d1bd2c742e8542d3236d705f2243f90c203abb0c47a3cb763a27fa40-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/4e0a7ba4cc182c612ad5cd8ca03b6135bc53bdc38baa70775cdc510472149e33/4e0a7ba4cc182c612ad5cd8ca03b6135bc53bdc38baa70775cdc510472149e33-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/82d82120ee2bc063e0ec20246311655447d15650b6b87c45424235e11311fc23/82d82120ee2bc063e0ec20246311655447d15650b6b87c45424235e11311fc23-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/84050a265058166b4ff571e7ec6c4e0e5c261433984c6259feeca6bd76dcdd2a/84050a265058166b4ff571e7ec6c4e0e5c261433984c6259feeca6bd76dcdd2a-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/853de0de60e8fc5989a8a484100490485a93bf71b1f02e4bc6789463a0840f37/853de0de60e8fc5989a8a484100490485a93bf71b1f02e4bc6789463a0840f37-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/ac95441949ca063acb0923d6637066563be687ad4b5af97339f069688589075f/ac95441949ca063acb0923d6637066563be687ad4b5af97339f069688589075f-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c1c2dadd7eb9b5206cb20ac245c65b08892a4fc42b90491c7080d940ceec932b/c1c2dadd7eb9b5206cb20ac245c65b08892a4fc42b90491c7080d940ceec932b-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/c391c7d625f744115d1ce91c5127b96b928dc1d4b04d5969d241dcefd3cff539/c391c7d625f744115d1ce91c5127b96b928dc1d4b04d5969d241dcefd3cff539-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/cff14bf1da8e4b718c7d99c583e91f65e0da09e3bb0f2f7e7b21e4ba90533220/cff14bf1da8e4b718c7d99c583e91f65e0da09e3bb0f2f7e7b21e4ba90533220-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/e730565e080e013d4d3cde93b0ada610180001cf080c92154266a2ad9a9ace05/e730565e080e013d4d3cde93b0ada610180001cf080c92154266a2ad9a9ace05-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/fe1e3adb4bb8c14a5023c6587634bb317ac4f10f196a6a24731c90ac8f737e34/fe1e3adb4bb8c14a5023c6587634bb317ac4f10f196a6a24731c90ac8f737e34-json.log\n  log does not need rotating (log is empty)", "stdout": "", "stdout_lines": [], "warnings": []}
changed: [coreos-cluster-6] => {"changed": true, "cmd": ["/usr/sbin/logrotate", "-fv", "/etc/logrotate.d/docker-container-logrotate"], "delta": "0:00:00.027831", "end": "2017-07-17 22:41:33.668081", "rc": 0, "start": "2017-07-17 22:41:33.640250", "stderr": "reading config file /etc/logrotate.d/docker-container-logrotate\nAllocating hash table for state file, size 64 entries\n\nHandling 1 logs\n\nrotating pattern: /var/lib/docker/containers/*/*.log  forced from command line (no old logs will be kept)\nempty log files are not rotated, old logs are removed\nconsidering log /var/lib/docker/containers/095ea87af3ab5718912c40952fbf324687728115cf4fec68b108cbc6a0cf1153/095ea87af3ab5718912c40952fbf324687728115cf4fec68b108cbc6a0cf1153-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/2ca44c6f2c21dd51d6da91bc97ae7b0f2a72b78a0a99ab588d50f9f0fffd8c6e/2ca44c6f2c21dd51d6da91bc97ae7b0f2a72b78a0a99ab588d50f9f0fffd8c6e-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/5fea68ec0b476a2d1b9940b66c18434ebb8fb819fbcc515cf45892cb31297a6d/5fea68ec0b476a2d1b9940b66c18434ebb8fb819fbcc515cf45892cb31297a6d-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log\n  log needs rotating\nconsidering log /var/lib/docker/containers/71b1857e769d0042ef8cc84dbbfa3b18a57828d09cb78106e6f5abff923e6d7c/71b1857e769d0042ef8cc84dbbfa3b18a57828d09cb78106e6f5abff923e6d7c-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/72cf12867465385c51fd6f925dd0c84bdc98b06eacf4cf5813327bea7cebb228/72cf12867465385c51fd6f925dd0c84bdc98b06eacf4cf5813327bea7cebb228-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/741ca934663fe90ce2b3288af7bfb30e5bb1f6ba0b9750554475a78755fb0638/741ca934663fe90ce2b3288af7bfb30e5bb1f6ba0b9750554475a78755fb0638-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/a9f160613f79b42b77861ec32e581e640eedc38a1c3362184b7e82af79119251/a9f160613f79b42b77861ec32e581e640eedc38a1c3362184b7e82af79119251-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/b974c45737a9e624294325ca71077a1cb95e3cfea7b011623caf0abd35958831/b974c45737a9e624294325ca71077a1cb95e3cfea7b011623caf0abd35958831-json.log\n  log does not need rotating (log is empty)considering log /var/lib/docker/containers/dcc483ead3a6882b29c3dcf4d05ecc604179e50434236331b94034e5bd43a068/dcc483ead3a6882b29c3dcf4d05ecc604179e50434236331b94034e5bd43a068-json.log\n  log does not need rotating (log is empty)rotating log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log, log->rotateCount is 0\ndateext suffix '-20170717'\nglob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'\nrenaming /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1 to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.2 (rotatecount 1, logstart 1, i 1), \nrenaming /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.0 to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1 (rotatecount 1, logstart 1, i 0), \nold log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.0 does not exist\ncopying /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log to /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.1\ntruncating /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log\nremoving old log /var/lib/docker/containers/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277/66890350b193eb7df98187d80f5be458022641931ff5ec312d5f02ee889eb277-json.log.2", "stdout": "", "stdout_lines": [], "warnings": []}

...

PLAY RECAP *********************************************************************
coreos-cluster-1           : ok=32   changed=4    unreachable=0    failed=0   
coreos-cluster-2           : ok=32   changed=4    unreachable=0    failed=0   
coreos-cluster-3           : ok=32   changed=4    unreachable=0    failed=0   
coreos-cluster-4           : ok=32   changed=4    unreachable=0    failed=0   
coreos-cluster-5           : ok=31   changed=2    unreachable=0    failed=0   
coreos-cluster-6           : ok=32   changed=4    unreachable=0    failed=0   
localhost      
```
