### PR TITLE
Add `rkt image gc` service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,13 @@ install_rkt_gc: True
 rkt_gc_frequency: "daily"
 rkt_gc_grace_period: "24h"
 ntp_servers: []
+
+install_custom_rkt: False
+custom_rkt_url: "https://github.com/rkt/rkt/releases/download/v1.30.0/rkt-v1.30.0.tar.gz"
+custom_rkt_sig_url: "https://github.com/rkt/rkt/releases/download/v1.30.0/rkt-v1.30.0.tar.gz.asc"
+coreos_app_signing_key: "https://coreos.com/dist/pubkeys/app-signing-pubkey.gpg"
+
+install_rkt_image_gc: False
+image_gc_rkt: "/usr/bin/rkt" # rkt executable to run 'image gc'
+rkt_image_gc_grace_period: "96h"
+rkt_image_gc_frequency: "daily"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,39 @@
   become: yes
   when: rkt_gc_timer.changed
 
+- name: Install custom rkt download service
+  template: src=custom-rkt-installer.service.j2 dest=/etc/systemd/system/custom-rkt-installer.service
+  become: yes
+  register: custom_rkt_dl
+  when: install_custom_rkt
+
+- name: Start custom rkt download service
+  service: name=custom-rkt-installer.service state=started
+  become: yes
+  when: custom_rkt_dl
+
+- name: Install rkt image gc service
+  become: yes
+  template: src=rkt-image-gc.service.j2 dest=/etc/systemd/system/rkt-image-gc.service
+  register: rkt_image_gc
+  when: install_rkt_image_gc
+
+- name: Enable rkt image gc service
+  service: name=rkt-image-gc.service enabled=yes
+  become: yes
+  when: rkt_image_gc.changed
+
+- name: Install rkt image gc timer
+  become: yes
+  template: src=rkt-image-gc.timer.j2 dest=/etc/systemd/system/rkt-image-gc.timer
+  register: rkt_image_gc_timer
+  when: install_rkt_image_gc
+
+- name: Enable rkt image gc timer
+  service: name=rkt-image-gc.timer enabled=yes state=started
+  become: yes
+  when: rkt_image_gc_timer.changed
+
 - name: Disable units
   become: yes
   file: src=/dev/null path=/etc/systemd/system/{{item}} state=link force=yes

--- a/templates/custom-rkt-installer.service.j2
+++ b/templates/custom-rkt-installer.service.j2
@@ -1,0 +1,16 @@
+# Adopted from https://github.com/rkt/rkt/blob/master/Documentation/install-rkt-in-coreos.md
+
+[Unit]
+Description=custom rkt installer
+Requires=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mkdir -p /opt/rkt
+ExecStart=/usr/bin/curl --silent -L -o /opt/rkt.tar.gz {{ custom_rkt_url }}
+ExecStart=/usr/bin/curl --silent -L -o /opt/rkt.tar.gz.sig {{ custom_rkt_sig_url }}
+ExecStart=/usr/bin/curl --silent -L -o /opt/coreos-app-signing-key.gpg {{ coreos_app_signing_key }}
+ExecStart=/usr/bin/gpg --keyring /tmp/gpg-keyring --no-default-keyring --import /opt/coreos-app-signing-key.gpg
+ExecStart=/usr/bin/gpg --keyring /tmp/gpg-keyring --no-default-keyring --verify /opt/rkt.tar.gz.sig /opt/rkt.tar.gz
+ExecStart=/usr/bin/tar --strip-components=1 -xf /opt/rkt.tar.gz -C /opt/rkt

--- a/templates/rkt-image-gc.service.j2
+++ b/templates/rkt-image-gc.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Garbage Collection for rkt images
+
+[Service]
+Type=oneshot
+ExecStart={{image_gc_rkt}} image gc --grace-period={{rkt_image_gc_grace_period}}

--- a/templates/rkt-image-gc.timer.j2
+++ b/templates/rkt-image-gc.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run rkt Image Garbage Collector {{rkt_image_gc_frequency}}
+
+[Timer]
+OnCalendar={{rkt_image_gc_frequency}}
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Includes oneshot service to download custom rkt executable. This is required to
get rkt-1.30+ (which is not yet packaged in CoreOS stable) that comes with a
bugfix for https://github.com/rkt/rkt/pull/3858